### PR TITLE
Improve handling of error messages.

### DIFF
--- a/Source/DafnyLS.IntegrationTest/DafnyLS.IntegrationTest.csproj
+++ b/Source/DafnyLS.IntegrationTest/DafnyLS.IntegrationTest.csproj
@@ -22,6 +22,12 @@
     <None Update="Lookup\TestFiles\foreign.dfy">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Synchronization\TestFiles\semanticError.dfy">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Synchronization\TestFiles\syntaxError.dfy">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/DafnyLS.IntegrationTest/Synchronization/CloseDocumentTest.cs
+++ b/Source/DafnyLS.IntegrationTest/Synchronization/CloseDocumentTest.cs
@@ -1,0 +1,48 @@
+using Microsoft.Dafny.LanguageServer.IntegrationTest.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using System.Threading.Tasks;
+
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization {
+  [TestClass]
+  public class CloseDocumentTest : DafnyLanguageServerTestBase {
+    private ILanguageClient _client;
+
+    [TestInitialize]
+    public async Task SetUp() {
+      _client = await InitializeClient();
+    }
+
+    private Task CloseDocumentAndWaitAsync(TextDocumentItem documentItem) {
+      _client.DidCloseTextDocument(new DidCloseTextDocumentParams {
+        TextDocument = documentItem
+      });
+      return _client.WaitForNotificationCompletionAsync(documentItem.Uri, CancellationToken);
+    }
+
+    [TestMethod]
+    public async Task DocumentIsUnloadedWhenClosed() {
+      var source = @"
+function GetConstant(): int {
+  1
+}".Trim();
+      var documentItem = CreateTestDocument(source);
+      await _client.OpenDocumentAndWaitAsync(documentItem, CancellationToken);
+      await CloseDocumentAndWaitAsync(documentItem);
+      Assert.IsFalse(Documents.TryGetDocument(documentItem.Uri, out var document));
+    }
+
+    [TestMethod]
+    public async Task DocumentStaysUnloadedWhenClosed() {
+      var source = @"
+function GetConstant(): int {
+  1
+}".Trim();
+      var documentItem = CreateTestDocument(source);
+      await CloseDocumentAndWaitAsync(documentItem);
+      Assert.IsFalse(Documents.TryGetDocument(documentItem.Uri, out var document));
+    }
+  }
+}

--- a/Source/DafnyLS.IntegrationTest/Synchronization/OpenDocumentTest.cs
+++ b/Source/DafnyLS.IntegrationTest/Synchronization/OpenDocumentTest.cs
@@ -1,10 +1,9 @@
 using Microsoft.Dafny.LanguageServer.IntegrationTest.Extensions;
-using Microsoft.Dafny;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client;
 using System.Threading.Tasks;
 
-namespace Microsoft.Dafny.LanguageServer.IntegrationTest {
+namespace Microsoft.Dafny.LanguageServer.IntegrationTest.Synchronization {
   [TestClass]
   public class OpenDocumentTest : DafnyLanguageServerTestBase {
     private ILanguageClient _client;

--- a/Source/DafnyLS.IntegrationTest/Synchronization/TestFiles/semanticError.dfy
+++ b/Source/DafnyLS.IntegrationTest/Synchronization/TestFiles/semanticError.dfy
@@ -1,0 +1,3 @@
+﻿method WithSemanticError() {
+  var x: int := "1";
+}

--- a/Source/DafnyLS.IntegrationTest/Synchronization/TestFiles/syntaxError.dfy
+++ b/Source/DafnyLS.IntegrationTest/Synchronization/TestFiles/syntaxError.dfy
@@ -1,0 +1,3 @@
+﻿method WithSyntaxError() {
+  "
+}

--- a/Source/DafnyLS/Handlers/DafnyTextDocumentHandler.cs
+++ b/Source/DafnyLS/Handlers/DafnyTextDocumentHandler.cs
@@ -49,7 +49,10 @@ namespace Microsoft.Dafny.LanguageServer.Handlers {
 
     public override Task<Unit> Handle(DidCloseTextDocumentParams notification, CancellationToken cancellationToken) {
       _logger.LogTrace("received close notification {}", notification.TextDocument.Uri);
-      _documents.CloseDocument(notification.TextDocument);
+      var document = _documents.CloseDocument(notification.TextDocument);
+      if(document != null) {
+        _diagnosticPublisher.HideDiagnostics(document);
+      }
       return Unit.Task;
     }
 

--- a/Source/DafnyLS/Language/DafnyLangParser.cs
+++ b/Source/DafnyLS/Language/DafnyLangParser.cs
@@ -2,6 +2,7 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -62,16 +63,11 @@ namespace Microsoft.Dafny.LanguageServer.Language {
         if(parseErrors != 0) {
           _logger.LogDebug("encountered {} errors while parsing {}", parseErrors, document.Uri);
         }
-        // TODO handle include errors
-        // TODO includes that are opened by the editor (i.e. managed by the DocumentDatabase) should be taken from there.
-        var includeError = Main.ParseIncludes(module, builtIns, new List<string>(), new Errors(errorReporter));
-        if(includeError != null) {
-          // TODO currently the diagnostic publisher ignores errors of foreign files. It should at least report
-          //      that there were some errors.
-          _logger.LogDebug("encountered error while parsing includes: {}", includeError);
+        if(!TryParseIncludesOfModule(module, builtIns, errorReporter)) {
+          _logger.LogDebug("encountered error while parsing the includes of {}", document.Uri);
         }
         // TODO Remove PoC workaround: the file system path is used as a program name to 
-        return new Microsoft.Dafny.Program(document.Uri.GetFileSystemPath(), module, builtIns, errorReporter);
+        return new Dafny.Program(document.Uri.GetFileSystemPath(), module, builtIns, errorReporter);
       } finally {
         _mutex.Release();
       }
@@ -79,6 +75,77 @@ namespace Microsoft.Dafny.LanguageServer.Language {
 
     public void Dispose() {
       _mutex.Dispose();
+    }
+
+    // TODO The following methods are based on the ones from DafnyPipeline/DafnyMain.cs.
+    //      It could be convenient to adapt them in the main-repo so location info could be extracted.
+    public bool TryParseIncludesOfModule(ModuleDecl module, BuiltIns builtIns, ErrorReporter errorReporter) {
+      var errors = new Errors(errorReporter);
+      var resolvedIncludes = new HashSet<Include>();
+      var dependencyMap = new DependencyMap();
+      dependencyMap.AddIncludes(resolvedIncludes);
+
+      bool newlyIncluded = true;
+      while(newlyIncluded) {
+        newlyIncluded = false;
+        var moduleIncludes = ((LiteralModuleDecl)module).ModuleDef.Includes;
+        dependencyMap.AddIncludes(moduleIncludes);
+        foreach(var include in moduleIncludes) {
+          bool isNewInclude = resolvedIncludes.Add(include);
+          if(isNewInclude) {
+            if(!TryParseInclude(include, module, builtIns, errorReporter, errors)) {
+              return false;
+            }
+          }
+        }
+      }
+
+      return true;
+    }
+
+    private bool TryParseInclude(Include include, ModuleDecl module, BuiltIns builtIns, ErrorReporter errorReporter, Errors errors) {
+      DafnyFile file;
+      try {
+        file = new DafnyFile(include.includedFilename);
+      } catch(IllegalDafnyFile e) {
+        errorReporter.Error(MessageSource.Parser, include.tok, $"Include of file {include.includedFilename} failed.");
+        _logger.LogDebug(e, "encountered include of illegal dafny file {}", include.includedFilename);
+        return false;
+      }
+      if(!TryParseFile(file, include, module, builtIns, errorReporter, errors)) {
+        return false;
+      }
+      return true;
+    }
+
+    private bool TryParseFile(
+      DafnyFile dafnyFile,
+      Include include,
+      ModuleDecl module,
+      BuiltIns builtIns,
+      ErrorReporter errorReporter,
+      Errors errors
+    ) {
+      try {
+        int errorCount = Parser.Parse(
+          dafnyFile.SourceFileName,
+          include,
+          module,
+          builtIns,
+          errors,
+          verifyThisFile: false,
+          compileThisFile: false
+        );
+        if(errorCount != 0) {
+          errorReporter.Error(MessageSource.Parser, include.tok, $"{errorCount} parse error(s) detected in {include.includedFilename}");
+          return false;
+        }
+      } catch(IOException e) {
+        errorReporter.Error(MessageSource.Parser, include.tok, $"Unable to open the include {include.includedFilename}.");
+        _logger.LogDebug(e, "could not open file {}", include.includedFilename);
+        return false;
+      }
+      return true;
     }
   }
 }

--- a/Source/DafnyLS/Language/DiagnosticPublisher.cs
+++ b/Source/DafnyLS/Language/DiagnosticPublisher.cs
@@ -17,6 +17,14 @@ namespace Microsoft.Dafny.LanguageServer.Language {
       _languageServer.PublishDiagnostics(ToPublishDiagnostics(document, cancellationToken));
     }
 
+    public void HideDiagnostics(DafnyDocument document) {
+      _languageServer.PublishDiagnostics(new PublishDiagnosticsParams {
+        Uri = document.Uri,
+        Version = document.Version,
+        Diagnostics = new Container<Diagnostic>()
+      });
+    }
+
     private static PublishDiagnosticsParams ToPublishDiagnostics(DafnyDocument document, CancellationToken cancellationToken) {
       return new PublishDiagnosticsParams {
         Uri = document.Uri,

--- a/Source/DafnyLS/Language/IDiagnosticPublisher.cs
+++ b/Source/DafnyLS/Language/IDiagnosticPublisher.cs
@@ -11,5 +11,11 @@ namespace Microsoft.Dafny.LanguageServer.Language {
     /// </summary>
     /// <param name="document">The document whose diagnostics should be published.</param>
     void PublishDiagnostics(DafnyDocument document, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Hides the previously published diagnostics of the specified dafny document.
+    /// </summary>
+    /// <param name="document">The document whose diagnostics should be hidden.</param>
+    void HideDiagnostics(DafnyDocument document);
   }
 }

--- a/Source/DafnyLS/Workspace/DocumentDatabase.cs
+++ b/Source/DafnyLS/Workspace/DocumentDatabase.cs
@@ -35,12 +35,13 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
       return databaseDocument;
     }
 
-    public bool CloseDocument(TextDocumentIdentifier documentId) {
-      if(!_documents.TryRemove(documentId.Uri, out var _)) {
+    public DafnyDocument? CloseDocument(TextDocumentIdentifier documentId) {
+      DafnyDocument? document;
+      if(!_documents.TryRemove(documentId.Uri, out document)) {
         _logger.LogTrace("the document {} was already closed", documentId);
-        return false;
+        return null;
       }
-      return true;
+      return document;
     }
     
     // TODO refresh loaded documents that depend on this document? Maybe at least when saving?

--- a/Source/DafnyLS/Workspace/IDocumentDatabase.cs
+++ b/Source/DafnyLS/Workspace/IDocumentDatabase.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Dafny.LanguageServer.Workspace {
     /// Closes the document with the specified ID.
     /// </summary>
     /// <param name="documentId">The ID of the document to close.</param>
-    /// <returns><c>true</c> if the document was closed successfully, <c>false</c> if no such document was opened.</returns>
-    bool CloseDocument(TextDocumentIdentifier documentId);
+    /// <returns>The closed dafny document, <c>null</c> if no such document was opened.</returns>
+    DafnyDocument? CloseDocument(TextDocumentIdentifier documentId);
 
     /// <summary>
     /// Loads (or updates if newer) the specified document into the database.


### PR DESCRIPTION
- Hide error messages when closing the document.
- Show a message that an include contains errors.