### PR TITLE
Add support for the statement expression.

### DIFF
--- a/Source/DafnyLS/Language/SyntaxTreeVisitor.cs
+++ b/Source/DafnyLS/Language/SyntaxTreeVisitor.cs
@@ -430,6 +430,9 @@
       case SeqDisplayExpr sequenceDisplayExpression:
         Visit(sequenceDisplayExpression);
         break;
+      case StmtExpr statementExpression:
+        Visit(statementExpression);
+        break;
       default:
         VisitUnknown(expression, expression.tok);
         break;
@@ -589,6 +592,11 @@
 
     public virtual void Visit(ExtendedPattern extendedPattern) {
       // TODO Visit the various pattern types.
+    }
+
+    public virtual void Visit(StmtExpr statementExpression) {
+      Visit(statementExpression.S);
+      Visit(statementExpression.E);
     }
   }
 }


### PR DESCRIPTION
Code like the following was unsupported until now:

```dafny
lemma SomeLemma() {
}

function Test(): int {
  SomeLemma();
  1
}
```

The body of the `Test` function represents a statement expression. This PR adds support to resolve symbols of such an expression.